### PR TITLE
Feature: iPhone 6S/6S Plus support

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/HapticGenerator.swift
+++ b/HapticGenerator.swift
@@ -3,6 +3,7 @@
 //  Created by Kane Cheshire on 16/12/2016.
 //
 import UIKit
+import AudioToolbox
 
 /// Generates haptics on supported devices.
 /// On devices that don't support haptics, the generator silently fails,
@@ -66,6 +67,20 @@ public struct Haptic {
         case notification(NotificationType)
     }
     
+    /// A struct that represents the types of haptic feedback (iPhone 6S/6S Plus only)
+    ///
+    /// - selectionOrSuccess: A feedback on selection or success notification
+    /// - impact: A feedback on impact
+    /// - error: A feedback on error
+    /// - warn: A feedback on warning
+    private struct HapticFeedbackIdentifier {
+        static let selection = SystemSoundID(1519)
+        static let impact = SystemSoundID(1520)
+        static let error = SystemSoundID(1521)
+        static let warn = SystemSoundID(1102)
+        static let success = SystemSoundID(4095)
+    }
+    
     let type: HapticType
     internal(set) var generator: Any? = nil
     
@@ -97,7 +112,7 @@ public struct Haptic {
     ///
     /// - Parameter prepareForReuse: If set to `true`, HapticGenerator will attempt to keep the taptic engine powered up for a few seconds, making it more responsive. Defaults to `false`.
     public func generate(prepareForReuse: Bool = false) {
-        if #available(iOS 10.0, *) {
+        if #available(iOS 10.0, *), hasTapticEngine() {
             switch type {
             case .selection: (generator as? UISelectionFeedbackGenerator)?.selectionChanged()
             case .impact: (generator as? UIImpactFeedbackGenerator)?.impactOccurred()
@@ -105,6 +120,17 @@ public struct Haptic {
             }
             if prepareForReuse {
                 prepareForUse()
+            }
+        } else if hasHapticEngine() {
+            switch type {
+            case .selection: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.selection)
+            case .impact: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.impact)
+            case .notification(let type):
+                switch(type) {
+                case .error: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.error)
+                case .success: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.success)
+                case .warning: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.warn)
+                }
             }
         }
     }
@@ -121,5 +147,86 @@ public struct Haptic {
             (generator as? UIFeedbackGenerator)?.prepare()
         }
     }
+}
+
+// MARK: - Extension that contains methods to determine current device & supported device(s)
+extension Haptic {
     
+    // MARK: - Enums -
+    // MARK: Internal
+    
+    /// An enum that represents the type of device (iPhone)
+    ///
+    /// - iPhone6S: An iPhone 6S
+    /// - iPhone6SPlus: An iPhone 6S Plus
+    /// - iPhone7: An iPhone 7
+    /// - iPhone7Plus: An iPhone 7 Plus
+    /// - iPhone8: An iPhone 8
+    /// - iPhone8Plus: An iPhone 8 Plus
+    /// - iPhoneX: An iPhone X
+    /// - unsupported: An unsupported device (iPhone 6 or below)
+    internal enum Device: String {
+        case iPhone6S
+        case iPhone6SPlus
+        case iPhone7
+        case iPhone7Plus
+        case iPhone8
+        case iPhone8Plus
+        case iPhoneX
+        case unsupported
+    }
+    
+    // MARK: - Methods -
+    // MARK: Internal
+    
+    /// Checks which device (iPhone model) the user has
+    ///
+    /// - Returns: A `Device` enum value that represents the user's device
+    internal func getCurrentDevice() -> Device {
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        guard let model = String(bytes: Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN)), encoding: .ascii)?.trimmingCharacters(in: .controlCharacters) else {
+            return .unsupported
+        }
+        switch model {
+        case "iPhone10,3", "iPhone10,6":
+            return .iPhoneX
+        case "iPhone10,2", "iPhone10,5":
+            return .iPhone8Plus
+        case "iPhone10,1", "iPhone10,4":
+            return .iPhone8
+        case "iPhone9,2", "iPhone9,4":
+            return .iPhone7Plus
+        case "iPhone9,1", "iPhone9,3":
+            return .iPhone7
+        case "iPhone8,2":
+            return .iPhone6SPlus
+        case "iPhone8,1":
+            return .iPhone6S
+        default:
+            return .unsupported
+        }
+    }
+    
+    
+    /// Checks whether the user's device has the Taptic Engine
+    ///
+    /// - Returns: `true` if the user's device has the Taptic Engine, `false` otherwise
+    internal func hasTapticEngine() -> Bool {
+        let supportedDevices = [Device.iPhone7, .iPhone7Plus, .iPhone8, .iPhone8Plus, .iPhoneX]
+        let currentDevice = getCurrentDevice()
+        return supportedDevices.contains(currentDevice)
+    }
+    
+    /// Checks whether the user's device has the Haptic Engine
+    ///
+    /// The devices that have a Taptic Engine can also create Haptic feedback, but we ignore those
+    /// devices because we want to use the Taptic Engine on those devices.
+    ///
+    /// - Returns: `true` if the user's device has the Haptic Engine, `false` otherwise
+    internal func hasHapticEngine() -> Bool {
+        let supportedDevices = [Device.iPhone6S, .iPhone6SPlus]
+        let currentDevice = getCurrentDevice()
+        return supportedDevices.contains(currentDevice)
+    }
 }

--- a/HapticGenerator.swift
+++ b/HapticGenerator.swift
@@ -8,7 +8,12 @@ import AudioToolbox
 /// Generates haptics on supported devices.
 /// On devices that don't support haptics, the generator silently fails,
 /// so you don't need to check for compatibility or OS version.
+///
+// MARK: - A struct that encapsulates haptic feedback generation -
 public struct Haptic {
+    
+    // MARK: - Properties -
+    // MARK: Static
     
     // Convenience for getting a selection haptic generator
     public static let selection = Haptic(type: .selection)
@@ -26,6 +31,14 @@ public struct Haptic {
     public static let warning = Haptic(type: .notification(.warning))
     // Convenience for getting a success haptic generator
     public static let success = Haptic(type: .notification(.success))
+    
+    // MARK: Internal
+    
+    let type: HapticType
+    internal(set) var generator: Any? = nil
+    
+    // MARK: - Enums -
+    // MARK: Public
     
     /// The type of haptic you want to generate.
     ///
@@ -67,6 +80,9 @@ public struct Haptic {
         case notification(NotificationType)
     }
     
+    // MARK: - Structs -
+    // MARK: Private
+    
     /// A struct that represents the types of haptic feedback (iPhone 6S/6S Plus only)
     ///
     /// - selectionOrSuccess: A feedback on selection or success notification
@@ -81,8 +97,8 @@ public struct Haptic {
         static let success = SystemSoundID(4095)
     }
     
-    let type: HapticType
-    internal(set) var generator: Any? = nil
+    // MARK: - Init -
+    // MARK: Public
     
     /// Creates a new generator configured with a haptic type.
     ///
@@ -102,6 +118,9 @@ public struct Haptic {
             }
         }
     }
+    
+    // MARK: - Methods -
+    // MARK: Public
     
     /// Generates a haptic.
     /// The type of haptic generates will be determined by the configuration at creation time.
@@ -207,7 +226,6 @@ extension Haptic {
             return .unsupported
         }
     }
-    
     
     /// Checks whether the user's device has the Taptic Engine
     ///

--- a/HapticGenerator.swift
+++ b/HapticGenerator.swift
@@ -131,7 +131,7 @@ public struct Haptic {
     ///
     /// - Parameter prepareForReuse: If set to `true`, HapticGenerator will attempt to keep the taptic engine powered up for a few seconds, making it more responsive. Defaults to `false`.
     public func generate(prepareForReuse: Bool = false) {
-        if #available(iOS 10.0, *), hasTapticEngine() {
+        if #available(iOS 10.0, *), hasNewerTapticEngine() {
             switch type {
             case .selection: (generator as? UISelectionFeedbackGenerator)?.selectionChanged()
             case .impact: (generator as? UIImpactFeedbackGenerator)?.impactOccurred()
@@ -140,7 +140,7 @@ public struct Haptic {
             if prepareForReuse {
                 prepareForUse()
             }
-        } else if hasHapticEngine() {
+        } else if hasOlderTapticEngine() {
             switch type {
             case .selection: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.selection)
             case .impact: AudioServicesPlaySystemSound(HapticFeedbackIdentifier.impact)
@@ -227,24 +227,21 @@ extension Haptic {
         }
     }
     
-    /// Checks whether the user's device has the Taptic Engine
+    /// Checks whether the user's device has the newer Taptic Engine
     ///
-    /// - Returns: `true` if the user's device has the Taptic Engine, `false` otherwise
-    internal func hasTapticEngine() -> Bool {
-        let supportedDevices = [Device.iPhone7, .iPhone7Plus, .iPhone8, .iPhone8Plus, .iPhoneX]
+    /// - Returns: `true` if the user's device has the newer Taptic Engine, `false` otherwise
+    internal func hasNewerTapticEngine() -> Bool {
+        let newDevices = [Device.iPhone7, .iPhone7Plus, .iPhone8, .iPhone8Plus, .iPhoneX]
         let currentDevice = getCurrentDevice()
-        return supportedDevices.contains(currentDevice)
+        return newDevices.contains(currentDevice)
     }
     
-    /// Checks whether the user's device has the Haptic Engine
+    /// Checks whether the user's device has the older Taptic Engine
     ///
-    /// The devices that have a Taptic Engine can also create Haptic feedback, but we ignore those
-    /// devices because we want to use the Taptic Engine on those devices.
-    ///
-    /// - Returns: `true` if the user's device has the Haptic Engine, `false` otherwise
-    internal func hasHapticEngine() -> Bool {
-        let supportedDevices = [Device.iPhone6S, .iPhone6SPlus]
+    /// - Returns: `true` if the user's device has the older Taptic Engine, `false` otherwise
+    internal func hasOlderTapticEngine() -> Bool {
+        let oldDevices = [Device.iPhone6S, .iPhone6SPlus]
         let currentDevice = getCurrentDevice()
-        return supportedDevices.contains(currentDevice)
+        return oldDevices.contains(currentDevice)
     }
 }


### PR DESCRIPTION
#### About this PR

This PR adds support for haptic feedback on iPhone 6S and 6S Plus.

- Tested on: iPhone X w/ iOS 12.0 (16A5364a)
- Needs testing on: iPhone 6S and 6S Plus

#### Notes

While the PR adds support for iPhone 6S and 6S Plus, the haptic feedback generated is simply an approximation of the feedback generated by the Taptic Engine on iPhone 7 or above. It's not exactly the same due to the limitations of the hardware, but it's close enough.

On older devices (such as iPhone 6 or below), no feedback will be generated because the necessary hardware does not exist. This could perhaps be mitigated by performing custom vibration patterns.