### PR TITLE
Add Thread.isMainThread check with assertionFailure to encourage safe usage

### DIFF
--- a/HapticGenerator.podspec
+++ b/HapticGenerator.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HapticGenerator'
-  s.version          = '4.0.0'
+  s.version          = '4.1.0'
   s.summary          = 'Seriously simple haptic generation on iOS.'
   s.description      = <<-DESC
   Apple's UIFeedbackGenerator subclasses are not difficult to use, but they are messy.

--- a/HapticGenerator.swift
+++ b/HapticGenerator.swift
@@ -3,6 +3,7 @@
 //  Created by Kane Cheshire on 16/12/2016.
 //
 import UIKit
+import Foundation
 
 /// Generates haptics on supported devices.
 /// On devices that don't support haptics, the generator silently fails,
@@ -92,10 +93,17 @@ public struct Haptic {
     ///
     /// It is safe to call this function on any version of iOS without checking availability.
     ///
+    /// It is only safe to call this function on the main thread. If it is called on any
+    /// other thread, an `assertionFailure` will be called.
+    ///
     /// - SeeAlso prepareForUse()
     ///
     /// - Parameter prepareForReuse: If set to `true`, HapticGenerator will attempt to keep the taptic engine powered up for a few seconds, making it more responsive. Defaults to `false`.
     public func generate(prepareForReuse: Bool = false) {
+        guard Thread.isMainThread else {
+            assertionFailure("Haptics should be generated on the main thread")
+            return
+        }
         guard #available(iOS 10.0, *) else { return }
         switch type {
         case .selection: (generator as? UISelectionFeedbackGenerator)?.selectionChanged()
@@ -118,8 +126,15 @@ public struct Haptic {
     ///
     /// It is safe to call this function on any version of iOS without checking availability.
     ///
+    /// It is only safe to call this function on the main thread. If it is called on any
+    /// other thread, an `assertionFailure` will be called.
+    ///
     /// - SeeAlso generate(prepareForReuse: Bool)
     public func prepareForUse() {
+        guard Thread.isMainThread else {
+            assertionFailure("Haptics should be prepared for reuse on the main thread")
+            return
+        }
         guard #available(iOS 10.0, *) else { return }
         (generator as? UIFeedbackGenerator)?.prepare()
     }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ then you can `prepareForUse` manually:
 Haptic.selection.prepareForUse()
 ```
 
+**Note:** Haptics should only be generated and prepared for reuse on the main thread.
+
 ## Why use this?
 
 Apple's `UIFeedbackGenerator` subclasses are not difficult to use, but they _are_ messy.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ then you can `prepareForUse` manually:
 Haptic.selection.prepareForUse()
 ```
 
-**Note:** Haptics should only be generated and prepared for reuse on the main thread.
+> **Note:** Haptics should only be generated and prepared for reuse on the main thread.
 
 ## Why use this?
 


### PR DESCRIPTION
As outlined in https://github.com/KaneCheshire/HapticGenerator/issues/7 this PR adds a `Thread.isMainThread` check to ensure that Haptics are only generated and prepared for reuse on the main thread to reduce the chance of crashes.

If `generate()` or `prepareForUse()` are called on a non-main thread, then an assertion failure will be called, causing execution to be stopped in debug mode, but continue in release mode.